### PR TITLE
use ->getTableName('Element') instead of omeka_elements in SQL

### DIFF
--- a/libraries/AccessibilityPlus/Form/Settings.php
+++ b/libraries/AccessibilityPlus/Form/Settings.php
@@ -9,7 +9,8 @@ class AccessibilityPlus_Form_Settings extends Omeka_Form
         $db = get_db();
         $valueOptions = array();
         $table = $db->getTable('Element');
-        $elements = $table->fetchObjects('SELECT * FROM omeka_elements WHERE element_set_id = 1');
+        $tableName = $db->getTableName('Element');
+        $elements = $table->fetchObjects("SELECT * FROM {$tableName} WHERE element_set_id = 1");        
         foreach ($elements as $element){
           $element_title = $element->getProperty('name');
           $valueOptions["$element_title"] = "$element_title";


### PR DESCRIPTION
I'm helping a friend that is trying to use the plugin, he is running into issues because he use "prefix" option in db.ini. 

This change use $db->getTableName('Element') to get the table name "prefix_element" and the SQL chage to "SELECT * FROM {$tableName} WHERE element_set_id = 1"

There might be a better way to do this, I just have about 30 minutes of experiences with Omeka